### PR TITLE
Remove grafana notifiers compose

### DIFF
--- a/compose-services.yml
+++ b/compose-services.yml
@@ -321,9 +321,6 @@ services:
         source: ./deployment/grafana/provisioning/alerting
         target: /etc/grafana/provisioning/alerting
       - type: bind
-        source: ./deployment/grafana/provisioning/notifiers
-        target: /etc/grafana/provisioning/notifiers
-      - type: bind
         source: ./deployment/grafana/grafana.ini
         target: /etc/grafana/grafana.ini
     depends_on:


### PR DESCRIPTION
### Issue: 
There is no source file for bind grafana notifiers in the compose yaml. This will lead to unable to find source file error. 

### Resolution: 
Remove to avoid.